### PR TITLE
Wrap Tampermonkey script with some delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ Install this script
     const searchParams = new URLSearchParams(window.location.search);
     const prompt = searchParams.get("PTquery");
     if (prompt) {
-        const textArea = document.querySelector("form textarea");
-        const submitButton = document.querySelector("form button");
 
-        if (!textArea || !submitButton) {
-            console.error("Cannot find required elements");
-        }
-
-        textArea.value = prompt;
         setTimeout(() => {
+            const textArea = document.querySelector("form textarea");
+            const submitButton = document.querySelector("form button");
+
+            if (!textArea || !submitButton) {
+                console.error("Cannot find required elements");
+            }
+
             textArea.value = prompt;
             submitButton.disabled = false;
             submitButton.click();


### PR DESCRIPTION
This was failing for me about 80-90% of the times, because the browser would load the script way faster than the ChatGPT window would appear.

This resulted in exceptions being thrown to the screen, and the entire thing not working.

Wrapping this under the delay like so fixed the issue. 